### PR TITLE
CRDL-272 Use the import job status endpoint to wait for the import job to complete before running tests

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/client/HttpClient.scala
+++ b/src/test/scala/uk/gov/hmrc/api/client/HttpClient.scala
@@ -46,8 +46,14 @@ trait HttpClient extends TestRunnerHttpClient:
       .withHttpHeaders(headers*)
       .delete()
 
-  def deleteCodelist(): Future[StandaloneWSResponse] = delete(s"$testOnlyHost/codelists")
+  def deleteCodelist(): StandaloneWSResponse = await(delete(s"$testOnlyHost/codelists"))
 
-  def deleteLastUpdated(): Future[StandaloneWSResponse] = delete(s"$testOnlyHost/last-updated")
+  def deleteLastUpdated(): StandaloneWSResponse = await(delete(s"$testOnlyHost/last-updated"))
 
-  def importCodelists(): Future[StandaloneWSResponse] = post(s"$testOnlyHost/codelists")
+  def importCodelists(): StandaloneWSResponse = await(post(s"$testOnlyHost/codelists"))
+
+  def getCodelistImportStatus(): StandaloneWSResponse = await(get(s"$testOnlyHost/codelists"))
+
+  def getCodelist(code: String): StandaloneWSResponse = await(get(s"$host/lists/$code"))
+
+  def getCodelistVersions(): StandaloneWSResponse = await(get(s"$host/lists"))


### PR DESCRIPTION
This PR uses the import job status endpoint from hmrc/crdl-cache#28 to wait for the import job to complete before running the tests.

This only runs the import process once at the start of the tests.

As a result, the "delete" tests were moved to the end of the test suite so that they don't impact the other tests.