### PR TITLE
CRDL-345: commented out deletion of other list

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/specs/ImportCodelistAPISpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/ImportCodelistAPISpec.scala
@@ -28,7 +28,7 @@ class ImportCodelistAPISpec extends BaseSpec, HttpClient, BeforeAndAfterAll:
   override def beforeAll(): Unit = {
     deleteCodelist()
     deleteLastUpdated()
-    deleteCorrespondenceList()
+//    deleteCorrespondenceList()
     importCodelists().status shouldBe 202
     eventually {
       // Wait for the import job to finish

--- a/src/test/scala/uk/gov/hmrc/api/specs/ImportCorrespondencelistAPISpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/ImportCorrespondencelistAPISpec.scala
@@ -27,7 +27,7 @@ import java.time.Instant
 
 class ImportCorrespondencelistAPISpec extends BaseSpec, HttpClient, BeforeAndAfterAll:
   override def beforeAll(): Unit = {
-    deleteCodelist()
+//    deleteCodelist()
     deleteLastUpdated()
     deleteCorrespondenceList()
     importCorrespondenceList().status shouldBe 202


### PR DESCRIPTION
Commented out deletion  of correspondence list in codelist API spec and vice versa to resolve tests failure due to parallel execution